### PR TITLE
fix skinny and pixelated texts

### DIFF
--- a/egui-opengl-internal/src/painter.rs
+++ b/egui-opengl-internal/src/painter.rs
@@ -398,9 +398,8 @@ impl Painter {
                             "Mismatch between texture size and texel count"
                         );
 
-                        let gamma = 1.0;
                         let data: Vec<u8> = image
-                            .srgba_pixels(Some(gamma))
+                            .srgba_pixels(None)
                             .flat_map(|a| a.to_array())
                             .collect();
 
@@ -436,9 +435,8 @@ impl Painter {
                         "Mismatch between texture size and texel count"
                     );
 
-                    let gamma = 1.0;
                     let pixels = image
-                        .srgba_pixels(Some(gamma))
+                        .srgba_pixels(None)
                         .flat_map(|a| a.to_array())
                         .collect();
 


### PR DESCRIPTION
Fixed the skinny texts 

before vs after (example-wnd)

before
![image](https://github.com/user-attachments/assets/5252c049-5d13-4cd9-b632-dcfb494ff630)

after
![image](https://github.com/user-attachments/assets/f1a3e1bf-336d-4199-a7ee-958870e44064)
